### PR TITLE
feat: 答案提示时长设置

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -156,6 +156,24 @@
           />
         </v-card-text>
       </v-card>
+      <v-expansion-panels class="mb-5">
+        <v-expansion-panel>
+          <v-expansion-panel-header>
+            答案提示时长……
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <v-slider
+              v-model="answerPromptTimeout"
+              max="5"
+              min="0.5"
+              step="0.5"
+              thumb-label
+              ticks
+              dense
+            />
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
       <v-expansion-panels>
         <v-expansion-panel>
           <v-expansion-panel-header>
@@ -301,7 +319,8 @@ export default {
         { text: '中文', value: 'meaning' },
         { text: '假名', value: 'kana' },
         { text: '日语汉字', value: 'kanji' }
-      ]
+      ],
+      answerPromptTimeout: 2.5
     }
   },
   computed: {
@@ -358,7 +377,7 @@ export default {
             this.currentCourseDone = true
           }
         }
-      }, 2500)
+      }, this.answerPromptTimeout * 1000)
       return this.correct
     },
     removeSelectedErrors () {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -358,7 +358,7 @@ export default {
             this.currentCourseDone = true
           }
         }
-      }, 1000)
+      }, 2500)
       return this.correct
     },
     removeSelectedErrors () {


### PR DESCRIPTION
- fix: longer answer prompt timeout
- feat: answer prompt timeout option

现在如果回答错误，显示答案时间太短，在第一个提交中把默认延时调到了 2.5 秒。

在第二个提交中加入了一个滑动条以调整延时。不过目前没有储存设置的功能，设置不能保存。
![image](https://user-images.githubusercontent.com/21151119/102493136-af547600-40ad-11eb-874a-0efbaffe11f0.png)
